### PR TITLE
ログイン画面作成・機能実装

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,7 +2,7 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /{document=**} {
-      allow read, write: if false;
+      allow read, write: if true;
     }
   }
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,9 +1,6 @@
-// import * as functions from 'firebase-functions';
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
 
-// // Start writing Firebase Functions
-// // https://firebase.google.com/docs/functions/typescript
-//
-// export const helloWorld = functions.https.onRequest((request, response) => {
-//   functions.logger.info("Hello logs!", {structuredData: true});
-//   response.send("Hello from Firebase!");
-// });
+admin.initializeApp(functions.config().firebase);
+
+export * from './user.function';

--- a/functions/src/user.function.ts
+++ b/functions/src/user.function.ts
@@ -1,0 +1,22 @@
+import * as functions from 'firebase-functions';
+
+import * as admin from 'firebase-admin';
+const db = admin.firestore();
+
+export const createUser = functions
+  .region('asia-northeast1')
+  .auth.user()
+  .onCreate((user) => {
+    return db.doc(`users/${user.uid}`).set({
+      name: user.displayName,
+      avatarURL: user.photoURL,
+      email: user.email,
+    });
+  });
+
+export const deleteUser = functions
+  .region('asia-northeast1')
+  .auth.user()
+  .onDelete((user) => {
+    return db.doc(`users/${user.uid}`).delete();
+  });

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,14 +5,17 @@ const routes: Routes = [
   {
     path: '',
     loadChildren: () =>
-      import('./main-shell/main-shell.module').then(
-        (m) => m.MainShellModule
-      ),
-  }
+      import('./main-shell/main-shell.module').then((m) => m.MainShellModule),
+  },
+  {
+    path: 'login',
+    loadChildren: () =>
+      import('./login/login.module').then((m) => m.LoginModule),
+  },
 ];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],
-  exports: [RouterModule]
+  exports: [RouterModule],
 })
-export class AppRoutingModule { }
+export class AppRoutingModule {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,11 +11,13 @@ import { AngularFirestoreModule } from '@angular/fire/firestore';
 import { AngularFireStorageModule } from '@angular/fire/storage';
 import { AngularFireFunctionsModule, REGION } from '@angular/fire/functions';
 import { AngularFireAuthModule } from '@angular/fire/auth';
+import {
+  MatSnackBarModule,
+  MAT_SNACK_BAR_DEFAULT_OPTIONS,
+} from '@angular/material/snack-bar';
 
 @NgModule({
-  declarations: [
-    AppComponent
-  ],
+  declarations: [AppComponent],
   imports: [
     BrowserModule,
     AppRoutingModule,
@@ -26,10 +28,12 @@ import { AngularFireAuthModule } from '@angular/fire/auth';
     AngularFireStorageModule,
     AngularFireFunctionsModule,
     AngularFireAuthModule,
+    MatSnackBarModule,
   ],
   providers: [
-    { provide: REGION, useValue: 'asia-northeast1' }
+    { provide: REGION, useValue: 'asia-northeast1' },
+    { provide: MAT_SNACK_BAR_DEFAULT_OPTIONS, useValue: { duration: 2500 } },
   ],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/app/interfaces/user-data.ts
+++ b/src/app/interfaces/user-data.ts
@@ -1,0 +1,7 @@
+export interface UserData {
+  uid: string;
+  name: string;
+  avatarURL: string;
+  email: string;
+  likedPostIds: string[];
+}

--- a/src/app/login/login-routing.module.ts
+++ b/src/app/login/login-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { LoginComponent } from './login/login.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    component: LoginComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class LoginRoutingModule {}

--- a/src/app/login/login.module.ts
+++ b/src/app/login/login.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { LoginRoutingModule } from './login-routing.module';
+import { LoginComponent } from './login/login.component';
+import { MatDividerModule } from '@angular/material/divider';
+
+@NgModule({
+  declarations: [LoginComponent],
+  imports: [CommonModule, LoginRoutingModule, MatDividerModule],
+})
+export class LoginModule {}

--- a/src/app/login/login/login.component.html
+++ b/src/app/login/login/login.component.html
@@ -1,0 +1,24 @@
+<div class="container">
+  <div class="login">
+    <h1 class="login__header">ログイン</h1>
+    <div class="action">
+      <button
+        class="action__button action__button--google"
+        (click)="googleLogin()"
+      >
+        Google
+      </button>
+      <p>または</p>
+      <button
+        class="action__button action__button--twitter"
+        (click)="twitterLogin()"
+      >
+        Twitter
+      </button>
+    </div>
+    <mat-divider></mat-divider>
+    <div class="login__text">
+      <p>ログインすると、投稿、いいねができるようになります</p>
+    </div>
+  </div>
+</div>

--- a/src/app/login/login/login.component.scss
+++ b/src/app/login/login/login.component.scss
@@ -1,0 +1,55 @@
+@import 'mixins';
+@import 'variables';
+
+.login {
+  max-width: 400px;
+  margin: 0 auto;
+  text-align: center;
+  margin-top: 80px;
+  border: 1px solid $color-main;
+  border-radius: 8px;
+  padding: 40px;
+  @include sp {
+    padding: 0 16px;
+  }
+  &__header {
+    color: $color-main;
+  }
+  &__text {
+    color: $color-font;
+  }
+}
+
+.action {
+  margin-bottom: 40px;
+  color: $color-font;
+  &__button {
+    display: block;
+    height: 48px;
+    width: 80%;
+    margin: 16px auto;
+    padding: 2px 25px;
+    border-radius: 30px;
+    line-height: 48px;
+    color: $color-font;
+    transition: ease-in-out 0.3s;
+    &--google {
+      border: 2px solid $color-font;
+    }
+    &--twitter {
+      border: 2px solid $color-font;
+      margin-bottom: 48px;
+    }
+    &--google:hover {
+      cursor: pointer;
+      border-left: 2px solid #4285f4;
+      border-top: 2px solid #db4437;
+      border-right: 2px solid #f4b400;
+      border-bottom: 2px solid #0f9d58;
+    }
+    &--twitter:hover {
+      cursor: pointer;
+      border: 2px solid #2aa1f1;
+    }
+  }
+}

--- a/src/app/login/login/login.component.spec.ts
+++ b/src/app/login/login/login.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LoginComponent } from './login.component';
+
+describe('LoginComponent', () => {
+  let component: LoginComponent;
+  let fixture: ComponentFixture<LoginComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [LoginComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/login/login/login.component.ts
+++ b/src/app/login/login/login.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnInit } from '@angular/core';
+import { AuthService } from 'src/app/services/auth.service';
+
+@Component({
+  selector: 'app-login',
+  templateUrl: './login.component.html',
+  styleUrls: ['./login.component.scss'],
+})
+export class LoginComponent implements OnInit {
+  isProcessing: boolean;
+
+  constructor(private authService: AuthService) {}
+
+  ngOnInit(): void {}
+
+  googleLogin(): void {
+    this.isProcessing = true;
+    this.authService.googleLogin().finally(() => (this.isProcessing = false));
+  }
+
+  twitterLogin(): void {
+    this.isProcessing = true;
+    this.authService.twitterLogin().finally(() => (this.isProcessing = false));
+  }
+}

--- a/src/app/main-shell/header/header.component.html
+++ b/src/app/main-shell/header/header.component.html
@@ -8,7 +8,25 @@
         <a href="" class="header__logo-link"> YAMAPATH </a>
       </h1>
       <div class="header__actions">
-        <div class="header__account"></div>
+        <ng-container *ngIf="authService.user$ | async as user; else notLogin">
+          <img
+            [matMenuTriggerFor]="menuRef"
+            class="header__account"
+            [src]="user.avatarURL"
+            alt=""
+          />
+        </ng-container>
+        <mat-menu #menuRef="matMenu">
+          <button mat-menu-item (click)="logout()">
+            <mat-icon>exit_to_app</mat-icon>
+            <span>ログアウト</span>
+          </button>
+        </mat-menu>
+        <ng-template #notLogin>
+          <button class="header__button" mat-button routerLink="/login">
+            ログイン
+          </button>
+        </ng-template>
       </div>
     </div>
   </div>

--- a/src/app/main-shell/header/header.component.scss
+++ b/src/app/main-shell/header/header.component.scss
@@ -15,13 +15,20 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    position: relative;
   }
   &__settings {
     color: #efefef;
   }
   &__title {
-    margin: 0;
     font-size: 18px;
+    display: block;
+    margin: 0 auto;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translateY(-50%) translateX(-50%);
+    -webkit-transform: translateY(-50%) translateX(-50%);
   }
   &__logo-link {
     color: #efefef;
@@ -36,5 +43,8 @@
     border: none;
     background-color: #efefef;
     background-size: cover;
+  }
+  &__button {
+    color: #efefef;
   }
 }

--- a/src/app/main-shell/header/header.component.ts
+++ b/src/app/main-shell/header/header.component.ts
@@ -1,15 +1,19 @@
 import { Component, OnInit } from '@angular/core';
+import { AuthService } from 'src/app/services/auth.service';
 
 @Component({
   selector: 'app-header',
   templateUrl: './header.component.html',
-  styleUrls: ['./header.component.scss']
+  styleUrls: ['./header.component.scss'],
 })
 export class HeaderComponent implements OnInit {
+  isProcessing: boolean;
 
-  constructor() { }
+  constructor(public authService: AuthService) {}
 
-  ngOnInit(): void {
+  ngOnInit(): void {}
+
+  logout(): void {
+    this.authService.logout();
   }
-
 }

--- a/src/app/main-shell/main-shell.module.ts
+++ b/src/app/main-shell/main-shell.module.ts
@@ -6,7 +6,8 @@ import { MainShellComponent } from './main-shell/main-shell.component';
 import { HeaderComponent } from './header/header.component';
 import { ToolbarComponent } from './toolbar/toolbar.component';
 import { MatIconModule } from '@angular/material/icon';
-
+import { MatMenuModule } from '@angular/material/menu';
+import { MatButtonModule } from '@angular/material/button';
 
 @NgModule({
   declarations: [MainShellComponent, HeaderComponent, ToolbarComponent],
@@ -14,6 +15,8 @@ import { MatIconModule } from '@angular/material/icon';
     CommonModule,
     MainShellRoutingModule,
     MatIconModule,
-  ]
+    MatMenuModule,
+    MatButtonModule,
+  ],
 })
-export class MainShellModule { }
+export class MainShellModule {}

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AuthService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -43,7 +43,7 @@ export class AuthService {
   logout(): void {
     this.afAuth.signOut().then(() => {
       this.snackBar.open('ログアウトしました', null);
-      this.router.navigateByUrl('/welcome');
+      this.router.navigateByUrl('/');
     });
   }
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -13,7 +13,6 @@ import { shareReplay, switchMap } from 'rxjs/operators';
 })
 export class AuthService {
   uid: string;
-  isProcessing: boolean;
 
   user$: Observable<UserData> = this.afAuth.authState.pipe(
     switchMap((afUser) => {
@@ -34,10 +33,35 @@ export class AuthService {
     private snackBar: MatSnackBar
   ) {}
 
-  login(): Promise<firebase.auth.UserCredential> {
+  private resolveLogin(): void {
+    this.router.navigateByUrl('/');
+    this.snackBar.open('ログインしました', null);
+  }
+
+  private rejectLogin(error: { message: any }): void {
+    console.error(error.message);
+    this.snackBar.open(
+      'ログインエラーです。数秒後にもう一度お試しください。',
+      null
+    );
+  }
+
+  googleLogin(): Promise<void> {
     const provider = new firebase.auth.GoogleAuthProvider();
     provider.setCustomParameters({ prompt: 'select_account' });
-    return this.afAuth.signInWithPopup(provider);
+    return this.afAuth
+      .signInWithPopup(provider)
+      .then(() => this.resolveLogin())
+      .catch((error) => this.rejectLogin(error));
+  }
+
+  twitterLogin(): Promise<void> {
+    const provider = new firebase.auth.TwitterAuthProvider();
+    provider.setCustomParameters({ prompt: 'select_account' });
+    return this.afAuth
+      .signInWithPopup(provider)
+      .then(() => this.resolveLogin())
+      .catch((error) => this.rejectLogin(error));
   }
 
   logout(): void {

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -67,7 +67,7 @@ export class AuthService {
   logout(): void {
     this.afAuth.signOut().then(() => {
       this.snackBar.open('ログアウトしました', null);
-      this.router.navigateByUrl('/');
+      this.router.navigateByUrl('/welcome');
     });
   }
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@angular/core';
+import { AngularFireAuth } from '@angular/fire/auth';
+import { AngularFirestore } from '@angular/fire/firestore';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import firebase from 'firebase';
+import { Observable, of } from 'rxjs';
+import { UserData } from '../interfaces/user-data';
+import { shareReplay, switchMap } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthService {
+  uid: string;
+  isProcessing: boolean;
+
+  user$: Observable<UserData> = this.afAuth.authState.pipe(
+    switchMap((afUser) => {
+      if (afUser) {
+        this.uid = afUser.uid;
+        return this.db.doc<UserData>(`users/${afUser.uid}`).valueChanges();
+      } else {
+        return of(null);
+      }
+    }),
+    shareReplay(1)
+  );
+
+  constructor(
+    private afAuth: AngularFireAuth,
+    private db: AngularFirestore,
+    private router: Router,
+    private snackBar: MatSnackBar
+  ) {}
+
+  login(): Promise<firebase.auth.UserCredential> {
+    const provider = new firebase.auth.GoogleAuthProvider();
+    provider.setCustomParameters({ prompt: 'select_account' });
+    return this.afAuth.signInWithPopup(provider);
+  }
+
+  logout(): void {
+    this.afAuth.signOut().then(() => {
+      this.snackBar.open('ログアウトしました', null);
+      this.router.navigateByUrl('/welcome');
+    });
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -19,6 +19,10 @@
       href="https://fonts.googleapis.com/css2?family=Baloo+Da+2:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@100;300;400;500;700;800;900&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <app-root></app-root>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -47,6 +47,16 @@ body {
 body {
   margin: 0;
   font-family: Roboto, 'Helvetica Neue', sans-serif;
+  background-color: #fafafa;
+}
+
+button {
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  outline: none;
+  padding: 0;
+  appearance: none;
 }
 
 .container {


### PR DESCRIPTION
Fixes #32 
Fixes #33

ログイン画面を作成しました。ご確認お願いいたします。

## 作業内容
- firestore.rulesを一時的に解除 7b08e0e
- ログイン機能追加 9ffba00
- ログインページへの導線を追加 b27cd32
- ログインページを作成・twitterログイン追加 8e9c04f
- ボタンのデフォルトのスタイルを初期化・全体の背景色追加 cdeba5e

## イメージ
![image](https://user-images.githubusercontent.com/60844124/99342228-bcbfea00-28ce-11eb-849c-3650b18ba478.png)
![image](https://user-images.githubusercontent.com/60844124/99342243-c6495200-28ce-11eb-84c6-c15cd736a09a.png)

