### PR TITLE
認証ガード

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
+import { GuestGuard } from './guards/guest.guard';
 import { NotFoundComponent } from './not-found/not-found.component';
 
 const routes: Routes = [
@@ -12,11 +13,15 @@ const routes: Routes = [
     path: 'login',
     loadChildren: () =>
       import('./login/login.module').then((m) => m.LoginModule),
+    canLoad: [GuestGuard],
+    canActivate: [GuestGuard],
   },
   {
     path: 'welcome',
     loadChildren: () =>
       import('./welcome/welcome.module').then((m) => m.WelcomeModule),
+    canLoad: [GuestGuard],
+    canActivate: [GuestGuard],
   },
   {
     path: '**',

--- a/src/app/guards/auth.guard.spec.ts
+++ b/src/app/guards/auth.guard.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AuthGuard } from './auth.guard';
+
+describe('AuthGuard', () => {
+  let guard: AuthGuard;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    guard = TestBed.inject(AuthGuard);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+});

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@angular/core';
+import {
+  CanActivate,
+  CanLoad,
+  Route,
+  UrlSegment,
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+  UrlTree,
+  Router,
+} from '@angular/router';
+import { Observable } from 'rxjs';
+import { map, take, tap } from 'rxjs/operators';
+import { AuthService } from '../services/auth.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthGuard implements CanActivate, CanLoad {
+  constructor(private authService: AuthService, private router: Router) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ):
+    | Observable<boolean | UrlTree>
+    | Promise<boolean | UrlTree>
+    | boolean
+    | UrlTree {
+    return this.authService.user$.pipe(
+      map((user) => !!user),
+      tap((isLoggedIn) => {
+        if (!isLoggedIn) {
+          this.router.navigateByUrl('/welcome');
+        }
+      })
+    );
+  }
+  canLoad(
+    route: Route,
+    segments: UrlSegment[]
+  ):
+    | Observable<boolean | UrlTree>
+    | Promise<boolean | UrlTree>
+    | boolean
+    | UrlTree {
+    return this.authService.user$.pipe(
+      map((user) => !!user),
+      take(1),
+      tap((isLoggedIn) => {
+        if (!isLoggedIn) {
+          this.router.navigateByUrl('/welcome');
+        }
+      })
+    );
+  }
+}

--- a/src/app/guards/guest.guard.spec.ts
+++ b/src/app/guards/guest.guard.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { GuestGuard } from './guest.guard';
+
+describe('GuestGuard', () => {
+  let guard: GuestGuard;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    guard = TestBed.inject(GuestGuard);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+});

--- a/src/app/guards/guest.guard.ts
+++ b/src/app/guards/guest.guard.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@angular/core';
+import {
+  CanActivate,
+  CanLoad,
+  Route,
+  UrlSegment,
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+  UrlTree,
+  Router,
+} from '@angular/router';
+import { Observable } from 'rxjs';
+import { map, tap, take } from 'rxjs/operators';
+import { AuthService } from '../services/auth.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GuestGuard implements CanActivate, CanLoad {
+  constructor(private authService: AuthService, private router: Router) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ):
+    | Observable<boolean | UrlTree>
+    | Promise<boolean | UrlTree>
+    | boolean
+    | UrlTree {
+    console.log('guestGuard');
+    return this.authService.user$.pipe(
+      map((user) => !user),
+      tap((isGuest) => {
+        if (!isGuest) {
+          this.router.navigateByUrl('/');
+        }
+      })
+    );
+  }
+  canLoad(
+    route: Route,
+    segments: UrlSegment[]
+  ):
+    | Observable<boolean | UrlTree>
+    | Promise<boolean | UrlTree>
+    | boolean
+    | UrlTree {
+    console.log('guestGuard2');
+    return this.authService.user$.pipe(
+      map((user) => !user),
+      take(1),
+      tap((isGuest) => {
+        if (!isGuest) {
+          this.router.navigateByUrl('/');
+        }
+      })
+    );
+  }
+}

--- a/src/app/main-shell/main-shell-routing.module.ts
+++ b/src/app/main-shell/main-shell-routing.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
+import { AuthGuard } from '../guards/auth.guard';
 import { MainShellComponent } from './main-shell/main-shell.component';
 
 const routes: Routes = [
@@ -12,11 +13,15 @@ const routes: Routes = [
         pathMatch: 'full',
         loadChildren: () =>
           import('./home/home.module').then((m) => m.HomeModule),
+        canLoad: [AuthGuard],
+        canActivate: [AuthGuard],
       },
       {
         path: 'create',
         loadChildren: () =>
           import('./create/create.module').then((m) => m.CreateModule),
+        canLoad: [AuthGuard],
+        canActivate: [AuthGuard],
       },
     ],
   },

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -22,8 +22,7 @@ export class AuthService {
       } else {
         return of(null);
       }
-    }),
-    shareReplay(1)
+    })
   );
 
   constructor(
@@ -66,8 +65,8 @@ export class AuthService {
 
   logout(): void {
     this.afAuth.signOut().then(() => {
-      this.snackBar.open('ログアウトしました', null);
       this.router.navigateByUrl('/welcome');
+      this.snackBar.open('ログアウトしました', null);
     });
   }
 }


### PR DESCRIPTION
fixes #5 

認証ガードを実装しました。ご確認お願いいたします。

authServiceのuser$を取得するときのshareReplay(1)がいると、ログイン・ログアウト時にリロードされないとページ遷移されない状態になってしまったので、shareReplay(1)を外しました。 f7beab3