### PR TITLE
記事カード・編集削除実装

### DIFF
--- a/src/app/interfaces/post.ts
+++ b/src/app/interfaces/post.ts
@@ -7,9 +7,11 @@ export interface Post {
   authorUid: string;
   likedCount: number;
   likedUserIds: string[];
-  position: google.maps.LatLngLiteral;
+  position?: google.maps.LatLngLiteral | null;
   createdAt: number;
+  updateAt?: number;
   isPublic: boolean;
+  isPosition: boolean;
   imageUrl?: string;
 }
 

--- a/src/app/main-shell/create/create-routing.module.ts
+++ b/src/app/main-shell/create/create-routing.module.ts
@@ -6,6 +6,12 @@ const routes: Routes = [
   {
     path: '',
     component: CreateComponent,
+    children: [
+      {
+        path: ':id',
+        component: CreateComponent,
+      },
+    ],
   },
 ];
 

--- a/src/app/main-shell/create/create/create.component.html
+++ b/src/app/main-shell/create/create/create.component.html
@@ -39,18 +39,29 @@
       <div class="form__image">
         <div class="form__image--label">画像を投稿</div>
         <div class="form__cropper">
-          <deer-crop-trigger
-            [options]="{
-              aspectRatio: 1 / 1
-            }"
-            (image)="onCroppedImage($event)"
-          ></deer-crop-trigger>
+          <ng-container *ngIf="oldImage; else notOldImage">
+            <deer-crop-trigger
+              [options]="{
+                aspectRatio: 1 / 1,
+                oldImageUrl: oldImage
+              }"
+              (image)="onCroppedImage($event)"
+            ></deer-crop-trigger>
+          </ng-container>
+          <ng-template #notOldImage>
+            <deer-crop-trigger
+              [options]="{
+                aspectRatio: 1 / 1
+              }"
+              (image)="onCroppedImage($event)"
+            ></deer-crop-trigger>
+          </ng-template>
         </div>
       </div>
 
       <div class="button-wrapper">
         <mat-slide-toggle
-          formControlName="public"
+          formControlName="isPublic"
           [(ngModel)]="isChecked"
           color="primary"
           class="form__public"
@@ -69,14 +80,26 @@
             >位置情報を含めない</ng-template
           ></mat-slide-toggle
         >
-        <button
-          mat-raised-button
-          color="primary"
-          [disabled]="form.invalid"
-          class="form__submit"
-        >
-          投稿
-        </button>
+        <ng-container *ngIf="!isEdit; else create">
+          <button
+            mat-raised-button
+            color="primary"
+            [disabled]="form.invalid"
+            class="form__submit"
+          >
+            投稿
+          </button>
+        </ng-container>
+        <ng-template #create>
+          <button
+            mat-raised-button
+            color="primary"
+            [disabled]="form.invalid"
+            class="form__submit"
+          >
+            更新
+          </button>
+        </ng-template>
       </div>
     </form>
   </div>

--- a/src/app/main-shell/create/create/create.component.ts
+++ b/src/app/main-shell/create/create/create.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { Validators, FormBuilder, FormControl } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { Post } from 'src/app/interfaces/post';
 import { PostService } from 'src/app/services/post.service';
 
 @Component({
@@ -12,9 +15,13 @@ import { PostService } from 'src/app/services/post.service';
 export class CreateComponent implements OnInit {
   isChecked = true;
   isPosition = true;
+  isEdit: boolean;
   imageFile: string;
+  oldImage: string;
 
+  private subscriptions: Subscription = new Subscription();
   private currentPosition: google.maps.LatLngLiteral;
+  private post: Post;
 
   form = this.fb.group({
     category: [
@@ -25,7 +32,7 @@ export class CreateComponent implements OnInit {
       ],
     ],
     text: ['', [Validators.required, Validators.maxLength(500)]],
-    public: [true],
+    isPublic: [true],
     isPosition: [true],
   });
 
@@ -71,10 +78,41 @@ export class CreateComponent implements OnInit {
     private fb: FormBuilder,
     private postService: PostService,
     private router: Router,
+    private route: ActivatedRoute,
     private snackBar: MatSnackBar
   ) {}
 
   ngOnInit(): void {
+    this.initForm();
+    this.getLocation();
+  }
+
+  initForm() {
+    this.route.queryParamMap.subscribe((map) => {
+      const id = map.get('id');
+      if (id) {
+        this.isEdit = true;
+        this.subscriptions.add(
+          this.postService
+            .getPostById(id)
+            .pipe(take(1))
+            .subscribe((post) => {
+              console.log(post);
+              this.form.setValue({
+                category: post.category,
+                text: post.text,
+                isPublic: post.isPublic,
+                isPosition: post.isPosition,
+              });
+              this.oldImage = post.imageUrl;
+              this.post = post;
+            })
+        );
+      }
+    });
+  }
+
+  getLocation() {
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition((position) => {
         this.currentPosition = {
@@ -90,14 +128,26 @@ export class CreateComponent implements OnInit {
   }
 
   submit(): void {
+    if (!this.currentPosition) {
+      this.currentPosition = null;
+    }
     if (!this.form.value.isPosition) {
       this.currentPosition = null;
     }
-    this.postService
-      .createPost(this.form.value, this.currentPosition, this.imageFile)
-      .then(() => {
-        this.snackBar.open('投稿しました', null);
-        this.router.navigateByUrl('/');
-      });
+    if (this.isEdit) {
+      this.postService
+        .updatePost(this.form.value, this.imageFile, this.post.postId)
+        .then(() => {
+          this.snackBar.open('更新しました');
+          this.router.navigateByUrl('/');
+        });
+    } else {
+      this.postService
+        .createPost(this.form.value, this.currentPosition, this.imageFile)
+        .then(() => {
+          this.snackBar.open('投稿しました', null);
+          this.router.navigateByUrl('/');
+        });
+    }
   }
 }

--- a/src/app/main-shell/create/create/create.component.ts
+++ b/src/app/main-shell/create/create/create.component.ts
@@ -97,7 +97,6 @@ export class CreateComponent implements OnInit {
             .getPostById(id)
             .pipe(take(1))
             .subscribe((post) => {
-              console.log(post);
               this.form.setValue({
                 category: post.category,
                 text: post.text,

--- a/src/app/pipes/category-to-icon-code.pipe.spec.ts
+++ b/src/app/pipes/category-to-icon-code.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { CategoryToIconCodePipe } from './category-to-icon-code.pipe';
+
+describe('CategoryToIconCodePipe', () => {
+  it('create an instance', () => {
+    const pipe = new CategoryToIconCodePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/pipes/category-to-icon-code.pipe.ts
+++ b/src/app/pipes/category-to-icon-code.pipe.ts
@@ -1,0 +1,25 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'categoryToIconCode',
+})
+export class CategoryToIconCodePipe implements PipeTransform {
+  transform(category: string): string {
+    switch (category) {
+      case 'danger':
+        return 'error';
+      case 'view':
+        return 'camera_alt';
+      case 'toilet':
+        return 'wc';
+      case 'water':
+        return 'local_drink';
+      case 'rest':
+        return 'nature_people';
+      case 'other':
+        return 'filter_tilt_shift';
+      default:
+        return null;
+    }
+  }
+}

--- a/src/app/pipes/category-to-japanese.pipe.spec.ts
+++ b/src/app/pipes/category-to-japanese.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { CategoryToJapanesePipe } from './category-to-japanese.pipe';
+
+describe('CategoryToJapanesePipe', () => {
+  it('create an instance', () => {
+    const pipe = new CategoryToJapanesePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/pipes/category-to-japanese.pipe.ts
+++ b/src/app/pipes/category-to-japanese.pipe.ts
@@ -1,0 +1,25 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'categoryToJapanese',
+})
+export class CategoryToJapanesePipe implements PipeTransform {
+  transform(category: string): string {
+    switch (category) {
+      case 'danger':
+        return '危険箇所';
+      case 'view':
+        return '絶景ポイント';
+      case 'toilet':
+        return 'お手洗い';
+      case 'water':
+        return '水場';
+      case 'rest':
+        return '休憩ポイント';
+      case 'other':
+        return 'その他';
+      default:
+        return null;
+    }
+  }
+}

--- a/src/app/services/post.service.ts
+++ b/src/app/services/post.service.ts
@@ -55,7 +55,6 @@ export class PostService {
   }
 
   getPostById(postId: string): Observable<Post> {
-    console.log(postId);
     return this.db.doc<Post>(`posts/${postId}`).valueChanges();
   }
 

--- a/src/app/shared/post-card/post-card.component.html
+++ b/src/app/shared/post-card/post-card.component.html
@@ -1,32 +1,77 @@
 <mat-card class="card">
-  <p>{{ post.category }}</p>
+  <div class="card__header">
+    <div class="card__title-wrapper">
+      <mat-icon class="category-icon--{{ post.category }}">{{
+        post.category | categoryToIconCode
+      }}</mat-icon>
+      <p>{{ post.category | categoryToJapanese }}</p>
+      <p class="card__created-at">
+        {{ post.createdAt | date: 'yyyy/MM/dd' }}
+      </p>
+    </div>
 
-  <mat-card-content class="card__body">
-    <p class="card__content">{{ post.text }}</p>
-  </mat-card-content>
-  <div
-    *ngIf="post.imageUrl"
-    [style.background-image]="'url(' + post.imageUrl + ')'"
-    class="card__image"
-    alt="image"
-  ></div>
-  <div class="card__bottom">
+    <ng-container *ngIf="user$ | async as user">
+      <button
+        *ngIf="user.uid === post.user.uid"
+        mat-icon-button
+        [matMenuTriggerFor]="menuRef"
+        class="card__edit"
+      >
+        <mat-icon>more_vert</mat-icon>
+      </button>
+      <mat-menu #menuRef="matMenu">
+        <button mat-menu-item (click)="editPost(post.postId)">
+          <mat-icon>edit</mat-icon>
+          <span>編集する</span>
+        </button>
+        <button mat-menu-item (click)="deletePost(post.postId)">
+          <mat-icon>delete</mat-icon>
+          <span>削除</span>
+        </button>
+      </mat-menu>
+    </ng-container>
+  </div>
+
+  <div class="card__body">
+    <p class="card__text">{{ post.text }}</p>
     <div
-      mat-card-avatar
-      [style.background-image]="'url(' + post.user.avatarURL + ')'"
-      class="card__avatar"
+      *ngIf="post.imageUrl"
+      [style.background-image]="'url(' + post.imageUrl + ')'"
+      class="card__image"
+      alt="image"
     ></div>
-    <mat-card-title>{{ post.user.name }}</mat-card-title>
-    <div>{{ likedCount }}</div>
-    <button *ngIf="isLiked; else yetLike" mat-button (click)="unLikePost()">
-      unLike
-    </button>
-    <ng-template #yetLike>
-      <button mat-button (click)="likePost()">like</button>
-    </ng-template>
+  </div>
 
-    <mat-card-subtitle>{{
-      post.createdAt | date: 'yyyy/MM/dd HH:mm'
-    }}</mat-card-subtitle>
+  <div class="card__bottom">
+    <div class="card__profile">
+      <div
+        mat-card-avatar
+        [style.background-image]="'url(' + post.user.avatarURL + ')'"
+        class="card__avatar"
+      ></div>
+      <p>{{ post.user.name }}</p>
+    </div>
+    <div class="like-wrapper">
+      <button
+        *ngIf="isLiked; else unLiked"
+        (click)="unLikePost()"
+        class="like-btn"
+        mat-icon-button
+        color="warn"
+      >
+        <mat-icon>favorite</mat-icon>
+      </button>
+      <ng-template #unLiked>
+        <button
+          [disabled]="isProcessing"
+          (click)="likePost()"
+          class="like-btn"
+          mat-icon-button
+        >
+          <mat-icon>favorite_border</mat-icon>
+        </button>
+      </ng-template>
+      <div>{{ likedCount }}</div>
+    </div>
   </div>
 </mat-card>

--- a/src/app/shared/post-card/post-card.component.scss
+++ b/src/app/shared/post-card/post-card.component.scss
@@ -5,9 +5,34 @@
 }
 
 .card {
-  &__avatar {
-    background: #fff center/cover;
-    margin-right: 10px;
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__title-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  &__created-at {
+    margin-left: 16px;
+    color: grey;
+  }
+
+  &__edit {
+    position: absolute;
+    top: 8px;
+    right: 0px;
+  }
+
+  &__text {
+    margin: 8px;
+    font-size: 16px;
+    text-align: left;
   }
 
   &__image {
@@ -20,16 +45,51 @@
     text-align: center;
   }
 
-  &__text {
-    padding: 0 10px;
-    font-size: 16px;
-    text-align: left;
-  }
-
   &__bottom {
     display: flex;
     justify-content: space-between;
-    padding: 0 0 0 10px;
+    align-items: center;
     margin-top: 30px;
   }
+
+  &__profile {
+    display: flex;
+    gap: 8px;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  &__avatar {
+    background: #fff center/cover;
+  }
+}
+
+.category-icon {
+  &--danger {
+    color: red;
+  }
+  &--view {
+    color: #00838e;
+  }
+  &--toilet {
+    color: #80b1fc;
+  }
+  &--water {
+    color: #0a74cf;
+  }
+  &--rest {
+    color: #3ca14e;
+  }
+  &--other {
+    color: #5f7c8a;
+  }
+}
+
+.like-wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.like-btn {
+  transition: color 3s;
 }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -9,9 +9,16 @@ import { MatIconModule } from '@angular/material/icon';
 import { PostCardComponent } from './post-card/post-card.component';
 import { MatCardModule } from '@angular/material/card';
 import { MatMenuModule } from '@angular/material/menu';
+import { CategoryToJapanesePipe } from '../pipes/category-to-japanese.pipe';
+import { CategoryToIconCodePipe } from '../pipes/category-to-icon-code.pipe';
 
 @NgModule({
-  declarations: [GoogleMapComponent, PostCardComponent],
+  declarations: [
+    GoogleMapComponent,
+    PostCardComponent,
+    CategoryToJapanesePipe,
+    CategoryToIconCodePipe,
+  ],
   imports: [
     CommonModule,
     SharedRoutingModule,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -80,8 +80,8 @@ p {
 
 .inner-container {
   max-width: 1080px;
-  margin: 64px auto;
-  padding: 0 16px;
+  margin: 0 auto;
+  padding: 64px 16px;
 }
 
 .mat-flat-button.mat-primary,


### PR DESCRIPTION
fixes #11 
fixes #40 

記事カードの見た目の調整と編集削除を実装しました。ご確認お願いいたします。

## イメージ

![image](https://user-images.githubusercontent.com/60844124/102154443-c122f700-3ebc-11eb-8db1-64430d3713e4.png)

https://www.loom.com/share/b36be5aea6324bfbac3bb6e7066831a6